### PR TITLE
(GH-4) Add support for DocFx projects in subfolders

### DIFF
--- a/src/Cake.Prca.Issues.DocFx.Tests/DocFxProviderFixture.cs
+++ b/src/Cake.Prca.Issues.DocFx.Tests/DocFxProviderFixture.cs
@@ -3,11 +3,12 @@
     using System.Collections.Generic;
     using System.IO;
     using Core.Diagnostics;
+    using Core.IO;
     using Testing;
 
     internal class DocFxProviderFixture
     {
-        public DocFxProviderFixture(string fileResourceName)
+        public DocFxProviderFixture(string fileResourceName, DirectoryPath docRootPath)
         {
             this.Log = new FakeLog { Verbosity = Verbosity.Normal };
 
@@ -17,7 +18,8 @@
                 {
                     this.Settings =
                         DocFxIssuesSettings.FromContent(
-                            sr.ReadToEnd());
+                            sr.ReadToEnd(),
+                            docRootPath);
                 }
             }
 

--- a/src/Cake.Prca.Issues.DocFx.Tests/DocFxProviderTests.cs
+++ b/src/Cake.Prca.Issues.DocFx.Tests/DocFxProviderTests.cs
@@ -17,7 +17,7 @@
                 var result = Record.Exception(() =>
                     new DocFxIssuesProvider(
                         null,
-                        DocFxIssuesSettings.FromContent("Foo")));
+                        DocFxIssuesSettings.FromContent("Foo", @"c:\Source\Cake.Prca")));
 
                 // Then
                 result.IsArgumentNullException("log");
@@ -38,11 +38,17 @@
 
         public sealed class TheReadIssuesMethod
         {
-            [Fact]
-            public void Should_Read_Issue_Correct()
+            [Theory]
+            [InlineData(@"c:\Source\Cake.Prca\docs", "docs/")]
+            [InlineData(@"docs", "docs/")]
+            [InlineData(@"c:\Source\Cake.Prca\src\docs", "src/docs/")]
+            [InlineData(@"src\docs", "src/docs/")]
+            [InlineData(@"c:\Source\Cake.Prca", "")]
+            [InlineData(@"/", "")]
+            public void Should_Read_Issue_Correct(string docRootPath, string docRelativePath)
             {
                 // Given
-                var fixture = new DocFxProviderFixture("docfx.json");
+                var fixture = new DocFxProviderFixture("docfx.json", docRootPath);
 
                 // When
                 var issues = fixture.ReadIssues().ToList();
@@ -51,7 +57,7 @@
                 issues.Count.ShouldBe(1);
                 CheckIssue(
                     issues[0],
-                    @"index.md",
+                    docRelativePath + @"index.md",
                     null,
                     "Build Document.LinkPhaseHandler.Apply Templates",
                     null,

--- a/src/Cake.Prca.Issues.DocFx.Tests/DocFxSettingsTests.cs
+++ b/src/Cake.Prca.Issues.DocFx.Tests/DocFxSettingsTests.cs
@@ -4,6 +4,7 @@
     using System.IO;
     using System.Linq;
     using System.Text;
+    using Core.IO;
     using Shouldly;
     using Xunit;
 
@@ -16,7 +17,7 @@
             {
                 // Given / When
                 var result = Record.Exception(() =>
-                    DocFxIssuesSettings.FromFilePath(null));
+                    DocFxIssuesSettings.FromFilePath(null, @"c:\Source\Cake.Prca\docs"));
 
                 // Then
                 result.IsArgumentNullException("logFilePath");
@@ -27,7 +28,7 @@
             {
                 // Given / When
                 var result = Record.Exception(() =>
-                    DocFxIssuesSettings.FromContent(null));
+                    DocFxIssuesSettings.FromContent(null, @"c:\Source\Cake.Prca\docs"));
 
                 // Then
                 result.IsArgumentNullException("logFileContent");
@@ -38,7 +39,7 @@
             {
                 // Given / When
                 var result = Record.Exception(() =>
-                    DocFxIssuesSettings.FromContent(string.Empty));
+                    DocFxIssuesSettings.FromContent(string.Empty, @"c:\Source\Cake.Prca\docs"));
 
                 // Then
                 result.IsArgumentOutOfRangeException("logFileContent");
@@ -49,29 +50,48 @@
             {
                 // Given / When
                 var result = Record.Exception(() =>
-                    DocFxIssuesSettings.FromContent(" "));
+                    DocFxIssuesSettings.FromContent(" ", @"c:\Source\Cake.Prca\docs"));
 
                 // Then
                 result.IsArgumentOutOfRangeException("logFileContent");
             }
 
             [Fact]
-            public void Should_Set_Property_Values_Passed_To_Constructor()
+            public void Should_Set_LogFileContent()
             {
                 // Given
                 const string logFileContent = "foo";
 
                 // When
-                var settings = DocFxIssuesSettings.FromContent(logFileContent);
+                var settings =
+                    DocFxIssuesSettings.FromContent(
+                        logFileContent,
+                        @"c:\Source\Cake.Prca\docs");
 
                 // Then
                 settings.LogFileContent.ShouldBe(logFileContent);
             }
 
             [Fact]
+            public void Should_Set_DocRootPath()
+            {
+                // Given
+                DirectoryPath docRootPath = @"c:\Source\Cake.Prca\docs";
+
+                // When
+                var settings =
+                    DocFxIssuesSettings.FromContent(
+                        "foo",
+                        docRootPath);
+
+                // Then
+                settings.DocRootPath.ShouldBe(docRootPath);
+            }
+
+            [Fact]
             public void Should_Read_File_From_Disk()
             {
-                var fileName = Path.GetTempFileName();
+                var fileName = System.IO.Path.GetTempFileName();
                 try
                 {
                     // Given
@@ -92,7 +112,7 @@
 
                     // When
                     var settings =
-                        DocFxIssuesSettings.FromFilePath(fileName);
+                        DocFxIssuesSettings.FromFilePath(fileName, @"c:\Source\Cake.Prca\docs");
 
                     // Then
                     settings.LogFileContent.ShouldBe(expected);

--- a/src/Cake.Prca.Issues.DocFx/DocFxIssuesProvider.cs
+++ b/src/Cake.Prca.Issues.DocFx/DocFxIssuesProvider.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using Core.Diagnostics;
+    using Core.IO;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -30,11 +31,18 @@
         /// <inheritdoc />
         protected override IEnumerable<ICodeAnalysisIssue> InternalReadIssues(PrcaCommentFormat format)
         {
+            // Determine path of the doc root.
+            var docRootPath = this.settings.DocRootPath;
+            if (docRootPath.IsRelative)
+            {
+                docRootPath = docRootPath.MakeAbsolute(this.PrcaSettings.RepositoryRoot);
+            }
+
             return
                 from logEntry in this.settings.LogFileContent.Split(new[] { '{', '}' }, StringSplitOptions.RemoveEmptyEntries).Select(x => "{" + x + "}")
                 let logEntryObject = JsonConvert.DeserializeObject<JToken>(logEntry)
                 let severity = (string)logEntryObject.SelectToken("message_severity")
-                let file = (string)logEntryObject.SelectToken("file")
+                let file = this.TryGetFile(logEntryObject, docRootPath)
                 let message = (string)logEntryObject.SelectToken("message")
                 let source = (string)logEntryObject.SelectToken("source") ?? "DocFx"
                 where
@@ -47,6 +55,38 @@
                         message,
                         0,
                         source);
+        }
+
+        /// <summary>
+        /// Reads the affected file path from a issue logged in a DocFx log file.
+        /// </summary>
+        /// <param name="token">JSON Token object for the current log entry.</param>
+        /// <param name="docRootPath">Absolute path to the root of the DocFx project.</param>
+        /// <returns>The full path to the affected file.</returns>
+        private string TryGetFile(
+            JToken token,
+            DirectoryPath docRootPath)
+        {
+            var fileName = (string)token.SelectToken("file");
+
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return null;
+            }
+
+            // Add path to repository root
+            fileName = docRootPath.CombineWithFilePath(fileName).FullPath;
+
+            // Make path relative to repository root.
+            fileName = fileName.Substring(this.PrcaSettings.RepositoryRoot.FullPath.Length);
+
+            // Remove leading directory separator.
+            if (fileName.StartsWith("/"))
+            {
+                fileName = fileName.Substring(1);
+            }
+
+            return fileName;
         }
     }
 }

--- a/src/Cake.Prca.Issues.DocFx/DocFxIssuesProviderAliases.cs
+++ b/src/Cake.Prca.Issues.DocFx/DocFxIssuesProviderAliases.cs
@@ -12,7 +12,8 @@
     public static class DocFxIssuesProviderAliases
     {
         /// <summary>
-        /// Gets an instance of a provider for warnings reported by DocFx using a log file from disk.
+        /// Gets an instance of a provider for warnings reported by DocFx using a log file from disk
+        /// for a DocFx project in the repository root.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="logFilePath">Path to the the DocFx log file.</param>
@@ -24,7 +25,7 @@
         ///     var repoRoot = new DirectoryPath("c:\repo");
         ///     ReportCodeAnalysisIssuesToPullRequest(
         ///         DocFxIssuesFromFilePath(
-        ///             new FilePath("C:\build\docfx.log")),
+        ///             "C:\build\docfx.log"),
         ///         TfsPullRequests(
         ///             new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository"),
         ///             "refs/heads/feature/myfeature",
@@ -42,11 +43,51 @@
             context.NotNull(nameof(context));
             logFilePath.NotNull(nameof(logFilePath));
 
-            return context.DocFxIssues(DocFxIssuesSettings.FromFilePath(logFilePath));
+            return context.DocFxIssuesFromFilePath(logFilePath, "/");
         }
 
         /// <summary>
-        /// Gets an instance of a provider for warnings reported by DocFx using log file content.
+        /// Gets an instance of a provider for warnings reported by DocFx using a log file from disk.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="logFilePath">Path to the the DocFx log file.</param>
+        /// <param name="docRootPath">Path to the root directory of the DocFx project.
+        /// Either the full path or the path relative to the repository root.</param>
+        /// <returns>Instance of a provider for warnings reported by DocFx.</returns>
+        /// <example>
+        /// <para>Report warnings reported by DocFx to a TFS pull request:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var repoRoot = new DirectoryPath("c:\repo");
+        ///     ReportCodeAnalysisIssuesToPullRequest(
+        ///         DocFxIssuesFromFilePath(
+        ///             "C:\build\docfx.log",
+        ///             "C:\build\doc"),
+        ///         TfsPullRequests(
+        ///             new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository"),
+        ///             "refs/heads/feature/myfeature",
+        ///             TfsAuthenticationNtlm()),
+        ///         repoRoot);
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(CakeAliasConstants.CodeAnalysisProviderCakeAliasCategory)]
+        public static ICodeAnalysisProvider DocFxIssuesFromFilePath(
+            this ICakeContext context,
+            FilePath logFilePath,
+            DirectoryPath docRootPath)
+        {
+            context.NotNull(nameof(context));
+            logFilePath.NotNull(nameof(logFilePath));
+            docRootPath.NotNull(nameof(docRootPath));
+
+            return context.DocFxIssues(DocFxIssuesSettings.FromFilePath(logFilePath, docRootPath));
+        }
+
+        /// <summary>
+        /// Gets an instance of a provider for warnings reported by DocFx using log file content
+        /// for a DocFx project in the repository root.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="logFileContent">Content of the the DocFx log file.</param>
@@ -76,7 +117,46 @@
             context.NotNull(nameof(context));
             logFileContent.NotNullOrWhiteSpace(nameof(logFileContent));
 
-            return context.DocFxIssues(DocFxIssuesSettings.FromContent(logFileContent));
+            return context.DocFxIssues(DocFxIssuesSettings.FromContent(logFileContent, "/"));
+        }
+
+        /// <summary>
+        /// Gets an instance of a provider for warnings reported by DocFx using log file content.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="logFileContent">Content of the the DocFx log file.</param>
+        /// <param name="docRootPath">Path to the root directory of the DocFx project.
+        /// Either the full path or the path relative to the repository root.</param>
+        /// <returns>Instance of a provider for warnings reported by DocFx.</returns>
+        /// <example>
+        /// <para>Report warnings reported by DocFx to a TFS pull request:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var repoRoot = new DirectoryPath("c:\repo");
+        ///     ReportCodeAnalysisIssuesToPullRequest(
+        ///         DocFxIssuesFromContent(
+        ///             logFileContent,
+        ///             "C:\build\doc"),
+        ///         TfsPullRequests(
+        ///             new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository"),
+        ///             "refs/heads/feature/myfeature",
+        ///             TfsAuthenticationNtlm()),
+        ///         repoRoot);
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(CakeAliasConstants.CodeAnalysisProviderCakeAliasCategory)]
+        public static ICodeAnalysisProvider DocFxIssuesFromContent(
+            this ICakeContext context,
+            string logFileContent,
+            DirectoryPath docRootPath)
+        {
+            context.NotNull(nameof(context));
+            logFileContent.NotNullOrWhiteSpace(nameof(logFileContent));
+            docRootPath.NotNull(nameof(docRootPath));
+
+            return context.DocFxIssues(DocFxIssuesSettings.FromContent(logFileContent, docRootPath));
         }
 
         /// <summary>
@@ -91,8 +171,7 @@
         /// <![CDATA[
         ///     var repoRoot = new DirectoryPath("c:\repo");
         ///     var settings =
-        ///         new DocFxIssuesSettings(
-        ///             new FilePath("C:\build\docfx.log"));
+        ///         new DocFxIssuesSettings("C:\build\docfx.log");
         ///
         ///     ReportCodeAnalysisIssuesToPullRequest(
         ///         DocFxIssues(settings),

--- a/src/Cake.Prca.Issues.DocFx/DocFxIssuesSettings.cs
+++ b/src/Cake.Prca.Issues.DocFx/DocFxIssuesSettings.cs
@@ -12,9 +12,14 @@
         /// Initializes a new instance of the <see cref="DocFxIssuesSettings"/> class.
         /// </summary>
         /// <param name="logFilePath">Path to the the DocFx log file.</param>
-        protected DocFxIssuesSettings(FilePath logFilePath)
+        /// <param name="docRootPath">Path to the root directory of the DocFx project.
+        /// Either the full path or the path relative to the repository root.</param>
+        protected DocFxIssuesSettings(FilePath logFilePath, DirectoryPath docRootPath)
         {
             logFilePath.NotNull(nameof(logFilePath));
+            docRootPath.NotNull(nameof(docRootPath));
+
+            this.DocRootPath = docRootPath;
 
             using (var stream = new FileStream(logFilePath.FullPath, FileMode.Open, FileAccess.Read))
             {
@@ -29,11 +34,15 @@
         /// Initializes a new instance of the <see cref="DocFxIssuesSettings"/> class.
         /// </summary>
         /// <param name="logFileContent">Content of the the DocFx log file.</param>
-        protected DocFxIssuesSettings(string logFileContent)
+        /// <param name="docRootPath">Path to the root directory of the DocFx project.
+        /// Either the full path or the path relative to the repository root.</param>
+        protected DocFxIssuesSettings(string logFileContent, DirectoryPath docRootPath)
         {
             logFileContent.NotNullOrWhiteSpace(nameof(logFileContent));
+            docRootPath.NotNull(nameof(docRootPath));
 
             this.LogFileContent = logFileContent;
+            this.DocRootPath = docRootPath;
         }
 
         /// <summary>
@@ -42,13 +51,21 @@
         public string LogFileContent { get; private set; }
 
         /// <summary>
+        /// Gets the path to the root directory of the DocFx project.
+        /// Either the full path or the path relative to the repository root.
+        /// </summary>
+        public DirectoryPath DocRootPath { get; private set; }
+
+        /// <summary>
         /// Returns a new instance of the <see cref="DocFxIssuesSettings"/> class from a log file on disk.
         /// </summary>
         /// <param name="logFilePath">Path to the DocFx log file.</param>
+        /// <param name="docRootPath">Path to the root directory of the DocFx project.
+        /// Either the full path or the path relative to the repository root.</param>
         /// <returns>Instance of the <see cref="DocFxIssuesSettings"/> class.</returns>
-        public static DocFxIssuesSettings FromFilePath(FilePath logFilePath)
+        public static DocFxIssuesSettings FromFilePath(FilePath logFilePath, DirectoryPath docRootPath)
         {
-            return new DocFxIssuesSettings(logFilePath);
+            return new DocFxIssuesSettings(logFilePath, docRootPath);
         }
 
         /// <summary>
@@ -56,10 +73,12 @@
         /// of a DocFx log file.
         /// </summary>
         /// <param name="logFileContent">Content of the DocFx log file.</param>
+        /// <param name="docRootPath">Path to the root directory of the DocFx project.
+        /// Either the full path or the path relative to the repository root.</param>
         /// <returns>Instance of the <see cref="DocFxIssuesSettings"/> class.</returns>
-        public static DocFxIssuesSettings FromContent(string logFileContent)
+        public static DocFxIssuesSettings FromContent(string logFileContent, DirectoryPath docRootPath)
         {
-            return new DocFxIssuesSettings(logFileContent);
+            return new DocFxIssuesSettings(logFileContent, docRootPath);
         }
     }
 }


### PR DESCRIPTION
Add support for DocFx projects by using alias which can be the path to the DocFx root directory passed.

Fixes #4 